### PR TITLE
Untyped module import

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
     "nyc": "^6.6.1",
     "react-addons-test-utils": "^15.1.0",
     "ts-loader": "^0.8.2",
-    "typescript": "^1.8.10",
+    "typescript": "^2.1.5",
     "typings": "^1.0.4",
     "webpack": "^1.13.0",
     "webpack-stream": "^3.2.0"
   },
   "dependencies": {
+    "rc-calendar": "^7.6.1",
     "react": "^15.0.2",
     "react-dom": "^15.0.2"
   }

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import {HelloWorld} from './components/HelloWorld'
+import * as Calendar from 'rc-calendar';
 
-ReactDOM.render(<HelloWorld
-        firstname="GLO-3112"
-        lastname="WEB"/>,
-    document.getElementById('app'));
+ReactDOM.render(<Calendar />, document.getElementById('app'));

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -6,6 +6,10 @@ export interface HelloWorldProps {
 }
 
 export class HelloWorld extends React.Component<HelloWorldProps, any> {
+    test() {
+      console.log(R.join(', ')(['Doe','Joe']));
+    }
+
     render() {
         return <h1>
             HELLO {this.props.firstname} {this.props.lastname}!

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -8,7 +8,7 @@ export interface HelloWorldProps {
 export class HelloWorld extends React.Component<HelloWorldProps, any> {
     render() {
         return <h1>
-            Hello {this.props.firstname} {this.props.lastname}!
+            HELLO {this.props.firstname} {this.props.lastname}!
         </h1>
     }
 }

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -6,10 +6,6 @@ export interface HelloWorldProps {
 }
 
 export class HelloWorld extends React.Component<HelloWorldProps, any> {
-    test() {
-      console.log(R.join(', ')(['Doe','Joe']));
-    }
-
     render() {
         return <h1>
             HELLO {this.props.firstname} {this.props.lastname}!

--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -1,1 +1,0 @@
-declare module "rc-calendar";

--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -1,0 +1,1 @@
+declare module "rc-calendar";

--- a/test/components/HelloWorldTest.tsx
+++ b/test/components/HelloWorldTest.tsx
@@ -16,5 +16,5 @@ test('HelloWorld props are defined properly', t => {
         firstname="GLO-3112"
         lastname="WEB"/>);
 
-    t.is(wrapper.find('h1').text(), 'Hello GLO-3112 WEB!');
+    t.is(wrapper.find('h1').text(), 'HELLO GLO-3112 WEB!');
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "outDir": "dist"
   },
   "files": [
-    "./typings/index.d.ts"
+    "./typings/index.d.ts",
+    "./src/lib.d.ts"
   ],
   "exclude": [
     "node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,7 @@
     "outDir": "dist"
   },
   "files": [
-    "./typings/index.d.ts",
-    "./src/lib.d.ts"
+    "./typings/index.d.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Update to TS 2.1 (TypeScript 2.1 is easier for setting up untyped modules.)

Install a module without dependencies (ex: rc-calendar)

Import module (`import * as Calendar from 'rc-calendar'`)

Works!
